### PR TITLE
Update Jackson dependencies to 2.13.5 to address CVE vulnerabilities

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,11 +57,11 @@ subprojects {
         }
 
         // They are once excluded from transitive dependencies of other dependencies,
-        // and added explicitly with versions exactly the same with older embulk-core (until 0.10.31).
-        implementation "com.fasterxml.jackson.core:jackson-annotations:2.6.7"
-        implementation "com.fasterxml.jackson.core:jackson-core:2.6.7"
-        implementation "com.fasterxml.jackson.core:jackson-databind:2.6.7.5"
-        implementation "com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.6.7"
+        // Updated to secure versions to address CVE vulnerabilities in 2.6.7
+        implementation "com.fasterxml.jackson.core:jackson-annotations:2.13.5"
+        implementation "com.fasterxml.jackson.core:jackson-core:2.13.5"
+        implementation "com.fasterxml.jackson.core:jackson-databind:2.13.5"
+        implementation "com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.13.5"
         implementation "javax.validation:validation-api:1.1.0.Final"
 
         implementation "org.embulk:embulk-util-json:0.3.0"

--- a/embulk-input-jdbc/gradle.lockfile
+++ b/embulk-input-jdbc/gradle.lockfile
@@ -1,10 +1,11 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.fasterxml.jackson.core:jackson-annotations:2.6.7=compileClasspath,runtimeClasspath
-com.fasterxml.jackson.core:jackson-core:2.6.7=compileClasspath,runtimeClasspath
-com.fasterxml.jackson.core:jackson-databind:2.6.7.5=compileClasspath,runtimeClasspath
-com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.6.7=compileClasspath,runtimeClasspath
+com.fasterxml.jackson.core:jackson-annotations:2.13.5=compileClasspath,runtimeClasspath
+com.fasterxml.jackson.core:jackson-core:2.13.5=compileClasspath,runtimeClasspath
+com.fasterxml.jackson.core:jackson-databind:2.13.5=compileClasspath,runtimeClasspath
+com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.13.5=compileClasspath,runtimeClasspath
+com.fasterxml.jackson:jackson-bom:2.13.5=compileClasspath,runtimeClasspath
 javax.validation:validation-api:1.1.0.Final=compileClasspath,runtimeClasspath
 org.embulk:embulk-spi:0.11=compileClasspath
 org.embulk:embulk-util-config:0.3.4=compileClasspath,runtimeClasspath

--- a/embulk-input-mysql/gradle.lockfile
+++ b/embulk-input-mysql/gradle.lockfile
@@ -1,10 +1,11 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.fasterxml.jackson.core:jackson-annotations:2.6.7=compileClasspath,runtimeClasspath
-com.fasterxml.jackson.core:jackson-core:2.6.7=compileClasspath,runtimeClasspath
-com.fasterxml.jackson.core:jackson-databind:2.6.7.5=compileClasspath,runtimeClasspath
-com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.6.7=compileClasspath,runtimeClasspath
+com.fasterxml.jackson.core:jackson-annotations:2.13.5=compileClasspath,runtimeClasspath
+com.fasterxml.jackson.core:jackson-core:2.13.5=compileClasspath,runtimeClasspath
+com.fasterxml.jackson.core:jackson-databind:2.13.5=compileClasspath,runtimeClasspath
+com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.13.5=compileClasspath,runtimeClasspath
+com.fasterxml.jackson:jackson-bom:2.13.5=compileClasspath,runtimeClasspath
 javax.validation:validation-api:1.1.0.Final=compileClasspath,runtimeClasspath
 mysql:mysql-connector-java:5.1.44=compileClasspath
 org.embulk:embulk-spi:0.11=compileClasspath

--- a/embulk-input-postgresql/gradle.lockfile
+++ b/embulk-input-postgresql/gradle.lockfile
@@ -1,10 +1,11 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.fasterxml.jackson.core:jackson-annotations:2.6.7=compileClasspath,runtimeClasspath
-com.fasterxml.jackson.core:jackson-core:2.6.7=compileClasspath,runtimeClasspath
-com.fasterxml.jackson.core:jackson-databind:2.6.7.5=compileClasspath,runtimeClasspath
-com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.6.7=compileClasspath,runtimeClasspath
+com.fasterxml.jackson.core:jackson-annotations:2.13.5=compileClasspath,runtimeClasspath
+com.fasterxml.jackson.core:jackson-core:2.13.5=compileClasspath,runtimeClasspath
+com.fasterxml.jackson.core:jackson-databind:2.13.5=compileClasspath,runtimeClasspath
+com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.13.5=compileClasspath,runtimeClasspath
+com.fasterxml.jackson:jackson-bom:2.13.5=compileClasspath,runtimeClasspath
 javax.validation:validation-api:1.1.0.Final=compileClasspath,runtimeClasspath
 org.embulk:embulk-spi:0.11=compileClasspath
 org.embulk:embulk-util-config:0.3.4=compileClasspath,runtimeClasspath

--- a/embulk-input-redshift/gradle.lockfile
+++ b/embulk-input-redshift/gradle.lockfile
@@ -1,10 +1,11 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.fasterxml.jackson.core:jackson-annotations:2.6.7=compileClasspath,runtimeClasspath
-com.fasterxml.jackson.core:jackson-core:2.6.7=compileClasspath,runtimeClasspath
-com.fasterxml.jackson.core:jackson-databind:2.6.7.5=compileClasspath,runtimeClasspath
-com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.6.7=compileClasspath,runtimeClasspath
+com.fasterxml.jackson.core:jackson-annotations:2.13.5=compileClasspath,runtimeClasspath
+com.fasterxml.jackson.core:jackson-core:2.13.5=compileClasspath,runtimeClasspath
+com.fasterxml.jackson.core:jackson-databind:2.13.5=compileClasspath,runtimeClasspath
+com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.13.5=compileClasspath,runtimeClasspath
+com.fasterxml.jackson:jackson-bom:2.13.5=compileClasspath,runtimeClasspath
 javax.validation:validation-api:1.1.0.Final=compileClasspath,runtimeClasspath
 org.embulk:embulk-spi:0.11=compileClasspath
 org.embulk:embulk-util-config:0.3.4=compileClasspath,runtimeClasspath

--- a/embulk-input-sqlserver/gradle.lockfile
+++ b/embulk-input-sqlserver/gradle.lockfile
@@ -1,10 +1,11 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.fasterxml.jackson.core:jackson-annotations:2.6.7=compileClasspath,runtimeClasspath
-com.fasterxml.jackson.core:jackson-core:2.6.7=compileClasspath,runtimeClasspath
-com.fasterxml.jackson.core:jackson-databind:2.6.7.5=compileClasspath,runtimeClasspath
-com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.6.7=compileClasspath,runtimeClasspath
+com.fasterxml.jackson.core:jackson-annotations:2.13.5=compileClasspath,runtimeClasspath
+com.fasterxml.jackson.core:jackson-core:2.13.5=compileClasspath,runtimeClasspath
+com.fasterxml.jackson.core:jackson-databind:2.13.5=compileClasspath,runtimeClasspath
+com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.13.5=compileClasspath,runtimeClasspath
+com.fasterxml.jackson:jackson-bom:2.13.5=compileClasspath,runtimeClasspath
 com.github.stephenc.jcip:jcip-annotations:1.0-1=compileClasspath,runtimeClasspath
 com.google.code.gson:gson:2.8.0=compileClasspath,runtimeClasspath
 com.microsoft.azure:adal4j:1.6.7=compileClasspath,runtimeClasspath


### PR DESCRIPTION
- Updated jackson-annotations from 2.6.7 to 2.13.5
- Updated jackson-core from 2.6.7 to 2.13.5
- Updated jackson-databind from 2.6.7.5 to 2.13.5
- Updated jackson-datatype-jdk8 from 2.6.7 to 2.13.5

This addresses multiple critical security vulnerabilities in Jackson 2.6.7:
- CVE-2017-7525: Remote code execution vulnerability
- CVE-2017-15095: Extended remote code execution vulnerability
- CVE-2017-17485: Additional remote code execution vulnerability
- CVE-2018-7489, CVE-2018-5968: Other security issues

All tests pass and build succeeds with the updated dependencies.

🤖 Generated with [Claude Code](https://claude.ai/code)