### PR TITLE
Add JitPack support for gem installation from GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,33 @@ See [embulk-input-sqlserver](embulk-input-sqlserver/).
 ## Others (generic JDBC)
 
 See [embulk-input-jdbc](embulk-input-jdbc/).
+
+## Installation via JitPack
+
+You can install these plugins directly from GitHub using JitPack:
+
+### Install from latest commit
+```bash
+# For PostgreSQL
+gem install embulk-input-postgresql --source https://jitpack.io/
+
+# For MySQL  
+gem install embulk-input-mysql --source https://jitpack.io/
+
+# For SQL Server
+gem install embulk-input-sqlserver --source https://jitpack.io/
+
+# For Redshift
+gem install embulk-input-redshift --source https://jitpack.io/
+```
+
+### Install from specific branch or tag
+```bash
+# Install from a specific branch (e.g., fix/jackson-bind-cve)
+gem install embulk-input-postgresql --source https://jitpack.io/com/github/embulk/embulk-input-jdbc/fix~jackson-bind-cve/
+
+# Install from a specific tag (e.g., v0.14.0)  
+gem install embulk-input-postgresql --source https://jitpack.io/com/github/embulk/embulk-input-jdbc/v0.14.0/
+```
+
+**Note**: Replace the plugin name (`embulk-input-postgresql`) with the specific plugin you want to install.

--- a/build.gradle
+++ b/build.gradle
@@ -178,6 +178,16 @@ subprojects {
         host = "https://rubygems.org"
     }
 
+    // JitPack support for gem installation
+    task installGem(type: Exec, dependsOn: gem) {
+        description = "Install gem locally for JitPack"
+        group = "gem"
+        commandLine "gem", "install", "--local", "${gem.outputs.files.singleFile}"
+        doFirst {
+            println "Installing gem: ${gem.outputs.files.singleFile}"
+        }
+    }
+
     test {
         // JDBC input plugins depend on local time zone to parse timestamp without time stamp and datetime types.
         jvmArgs "-Duser.country=FI", "-Duser.timezone=Europe/Helsinki"

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,15 @@
+jdk:
+  - openjdk8
+before_install:
+  - echo "Setting up Java 8 environment"
+  - export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
+  - export PATH=$JAVA_HOME/bin:$PATH
+  - java -version
+install:
+  - echo "Building gems with Gradle"
+  - ./gradlew clean
+  - ./gradlew gem -xsignMavenPublication -xtest
+  - ./gradlew publishToMavenLocal -xsignMavenPublication -xtest
+env:
+  GRADLE_OPTS: "-Dorg.gradle.daemon=false -Dorg.gradle.configureondemand=false"
+  JAVA_TOOL_OPTIONS: "-Dfile.encoding=UTF-8"


### PR DESCRIPTION
- Added jitpack.yml configuration for automated gem building
- Added installGem task to build.gradle for JitPack integration
- Updated README.md with JitPack installation instructions
- Supports installation from specific branches and tags
- Enables direct gem install from GitHub repository

Users can now install plugins directly from GitHub: gem install embulk-input-postgresql --source https://jitpack.io/

🤖 Generated with [Claude Code](https://claude.ai/code)